### PR TITLE
Support for Python3.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 build
 dist
 htmlcov
+.tox

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,9 @@
+PENDING
+=======
+
+* support for python3 via source-level compatibility
+
+
 0.1.0 - 2012-03-14
 ==================
 

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 
 import os
+import sys
 from setuptools import setup, find_packages
 
 here = os.path.abspath(os.path.dirname(__file__))
@@ -10,7 +11,9 @@ with open(os.path.join(here, 'README.rst')) as f:
 with open(os.path.join(here, 'CHANGES.txt')) as f:
     CHANGES = f.read()
 
-requires = ['unittest2']
+requires = []
+if sys.version_info < (2, 7):
+    requires.append('unittest2')  # pragma: nocover
 
 setup(name='tokenlib',
       version='0.1.0',

--- a/tokenlib/tests/test_utils.py
+++ b/tokenlib/tests/test_utils.py
@@ -2,48 +2,54 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 
+import sys
 import hashlib
-import unittest2
+from binascii import unhexlify
+
+if sys.version_info < (2, 7):
+    import unittest2 as unittest  # pragma: nocover
+else:
+    import unittest  # pragma: nocover  # NOQA
 
 from tokenlib.utils import strings_differ, HKDF, HKDF_extract
 
 
-class TestUtils(unittest2.TestCase):
+class TestUtils(unittest.TestCase):
 
     def test_strings_differ(self):
         # We can't really test the timing-invariance, but
         # we can test that we actually compute equality!
-        self.assertTrue(strings_differ("", "a"))
-        self.assertTrue(strings_differ("b", "a"))
-        self.assertTrue(strings_differ("cc", "a"))
-        self.assertTrue(strings_differ("cc", "aa"))
-        self.assertFalse(strings_differ("", ""))
-        self.assertFalse(strings_differ("D", "D"))
-        self.assertFalse(strings_differ("EEE", "EEE"))
+        self.assertTrue(strings_differ(b"", b"a"))
+        self.assertTrue(strings_differ(b"b", b"a"))
+        self.assertTrue(strings_differ(b"cc", b"a"))
+        self.assertTrue(strings_differ(b"cc", b"aa"))
+        self.assertFalse(strings_differ(b"", b""))
+        self.assertFalse(strings_differ(b"D", b"D"))
+        self.assertFalse(strings_differ(b"EEE", b"EEE"))
 
     def test_hkdf_rfc_case1(self):
         hashmod = hashlib.sha256
-        IKM = "0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b".decode("hex")
-        salt = "000102030405060708090a0b0c".decode("hex")
-        info = "f0f1f2f3f4f5f6f7f8f9".decode("hex")
+        IKM = unhexlify(b"0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b")
+        salt = unhexlify(b"000102030405060708090a0b0c")
+        info = unhexlify(b"f0f1f2f3f4f5f6f7f8f9")
         L = 42
-        PRK = "077709362c2e32df0ddc3f0dc47bba63".decode("hex") +\
-              "90b6c73bb50f9c3122ec844ad7c2b3e5".decode("hex")
-        OKM = "3cb25f25faacd57a90434f64d0362f2a".decode("hex") +\
-              "2d2d0a90cf1a5a4c5db02d56ecc4c5bf".decode("hex") +\
-              "34007208d5b887185865".decode("hex")
+        PRK = unhexlify(b"077709362c2e32df0ddc3f0dc47bba63") +\
+              unhexlify(b"90b6c73bb50f9c3122ec844ad7c2b3e5")
+        OKM = unhexlify(b"3cb25f25faacd57a90434f64d0362f2a") +\
+              unhexlify(b"2d2d0a90cf1a5a4c5db02d56ecc4c5bf") +\
+              unhexlify(b"34007208d5b887185865")
         self.assertEquals(HKDF_extract(salt, IKM, hashmod), PRK)
         self.assertEquals(HKDF(IKM, salt, info, L, hashmod), OKM)
 
     def test_hkdf_rfc_case7(self):
         hashmod = hashlib.sha1
-        IKM = "0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c".decode("hex")
+        IKM = unhexlify(b"0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c")
         salt = None
-        info = ""
+        info = b""
         L = 42
-        PRK = "2adccada18779e7c2077ad2eb19d3f3e731385dd".decode("hex")
-        OKM = "2c91117204d745f3500d636a62f64f0a".decode("hex") +\
-              "b3bae548aa53d423b0d1f27ebba6f5e5".decode("hex") +\
-              "673a081d70cce7acfc48".decode("hex")
+        PRK = unhexlify(b"2adccada18779e7c2077ad2eb19d3f3e731385dd")
+        OKM = unhexlify(b"2c91117204d745f3500d636a62f64f0a") +\
+              unhexlify(b"b3bae548aa53d423b0d1f27ebba6f5e5") +\
+              unhexlify(b"673a081d70cce7acfc48")
         self.assertEquals(HKDF_extract(salt, IKM, hashmod), PRK)
         self.assertEquals(HKDF(IKM, salt, info, L, hashmod), OKM)

--- a/tokenlib/utils.py
+++ b/tokenlib/utils.py
@@ -2,13 +2,26 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 
+import sys
 import math
 import hmac
+import base64
 import hashlib
 
 
+if sys.version_info > (3,):  # pragma: nocover
+    IS_PY3 = True
+    xrange = range
+    byte_to_int = lambda x: x
+    int_to_byte = lambda x: bytes((x,))
+else:  # pragma: nocover
+    IS_PY3 = False
+    byte_to_int = ord
+    int_to_byte = chr
+
+
 def strings_differ(string1, string2):
-    """Check whether two strings differ while avoiding timing attacks.
+    """Check whether two bytestrings differ while avoiding timing attacks.
 
     This function returns True if the given strings differ and False
     if they are equal.  It's careful not to leak information about *where*
@@ -22,14 +35,14 @@ def strings_differ(string1, string2):
         return True
     invalid_bits = 0
     for a, b in zip(string1, string2):
-        invalid_bits += ord(a) ^ ord(b)
+        invalid_bits += byte_to_int(a) ^ byte_to_int(b)
     return invalid_bits != 0
 
 
 def HKDF_extract(salt, IKM, hashmod=hashlib.sha1):
     """HKDF-Extract; see RFC-5869 for the details."""
     if salt is None:
-        salt = "\x00" * hashmod().digest_size
+        salt = b"\x00" * hashmod().digest_size
     return hmac.new(salt, IKM, hashmod).digest()
 
 
@@ -38,16 +51,39 @@ def HKDF_expand(PRK, info, L, hashmod=hashlib.sha1):
     digest_size = hashmod().digest_size
     N = int(math.ceil(L * 1.0 / digest_size))
     assert N <= 255
-    T = ""
+    T = b""
     output = []
     for i in xrange(1, N + 1):
-        data = T + info + chr(i)
+        data = T + info + int_to_byte(i)
         T = hmac.new(PRK, data, hashmod).digest()
         output.append(T)
-    return "".join(output)[:L]
+    return b"".join(output)[:L]
 
 
 def HKDF(secret, salt, info, size, hashmod=hashlib.sha1):
     """HKDF-extract-and-expand as a single function."""
     PRK = HKDF_extract(salt, secret, hashmod)
     return HKDF_expand(PRK, info, size, hashmod)
+
+
+def encode_token_bytes(data):
+    """Encode token data from bytes into a native string.
+
+    This function base64-encodes binary data representing a token into a
+    urlsafe native string.
+    """
+    data = base64.urlsafe_b64encode(data)
+    if IS_PY3:  # pragma: nocover
+        data = data.decode("ascii")
+    return data
+
+
+def decode_token_bytes(data):
+    """Decode token data from a native string into bytes.
+
+    This function base64-decodes binary data representing a token from a
+    urlsafe native string.
+    """
+    if IS_PY3:  # pragma: nocover
+        data = data.encode("ascii")
+    return base64.urlsafe_b64decode(data)

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,12 @@
+[tox]
+envlist = py26, py27, py32, py33
+
+[testenv]
+deps= coverage
+commands = coverage erase
+           coverage run setup.py test
+           coverage report --include=*tokenlib*
+
+[testenv:py26]
+deps= coverage
+      unittest2


### PR DESCRIPTION
This commit makes tokenlib compatible with python26 through python33, via source-level compatibility.

The only real complication is unicode versus bytes.  I've gone with the following approach:
- HKDF and related lower-level signing stuff deal only in bytes, and never do any encoding/decoding.
- High-level token functions deal only with unicode strings, because that data is always b64urlsafe and is designed for embedding in web requests.

This means that tokens are always unicode.  The calling code most likely wants a "native string" as defined in PEP3333.  They get that directly in python3, and via implicit conversion in python2.  The conversion is safe because tokens are always ascii.

@tarekziade r?
